### PR TITLE
add :not([type="importmap"]) to script selector

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ export default async function (url: string, props: ComponentOptions = {}): Promi
   ele.innerHTML = sfc;
   const template = ele.querySelector('template')?.innerHTML;
   const styleList = ele.querySelectorAll('style');
-  const script = ele.querySelector('script');
+  const script = ele.querySelector('script:not([type="importmap"])');
   let sfcProps: ComponentOptions = {};
 
   // 1、es module无法从外部js直接获取导出模块


### PR DESCRIPTION
Chrome inserts the import map script in to the newly created html element, this breaks vueImport as the script is now the import map and not the sfc script, to mitigate this I added changed the script selector to `script:not([type="importmap"])`.